### PR TITLE
Wowhead tooltips

### DIFF
--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -17,7 +17,7 @@ export default function Item({ item }: { item: ItemType }) {
       </div>
       {item.wowheadId ? (
         <div
-          className="relative mx-2 shrink-0 size-8 lg:size-12 my-auto"
+          className="relative mx-2 shrink-0 size-10 lg:size-12 my-auto"
           onClick={(e) => {
             e.stopPropagation();
           }}
@@ -25,16 +25,10 @@ export default function Item({ item }: { item: ItemType }) {
           <a
             href={`https://wowhead.com/item=${item.wowheadId}`}
             target="_blank"
-          >
-            <img
-              src="wowhead-small.png"
-              alt="Link to Wowhead item page."
-              className="rounded-md"
-            />
-          </a>
+          />
         </div>
       ) : null}
-      <div className="relative shrink-0 size-8 lg:size-12 my-auto">
+      <div className="relative shrink-0 size-10 lg:size-10 my-auto">
         <img
           src="bronze.jpg"
           alt="Icon for MOP Remix Bronze currency."
@@ -51,7 +45,7 @@ export default function Item({ item }: { item: ItemType }) {
         readOnly
         // operation below works fine without the OR condition, but makes react throw an error if checkedMap[item.id] produces a falsy value instead of a bool
         checked={appState.checkedMap[item.id] || false}
-        className="size-8 lg:size-12 mx-2 my-auto text-emerald-900 rounded-md cursor-pointer"
+        className="size-10 lg:size-10 mx-2 my-auto text-emerald-900 rounded-md cursor-pointer"
       />
     </div>
   );

--- a/app/_components/WowheadScript.tsx
+++ b/app/_components/WowheadScript.tsx
@@ -1,0 +1,12 @@
+import Script from "next/script"
+
+export default function WowheadScript() {
+  return (
+    <>
+      <Script id="wowhead-tt">
+        {`const whTooltips = {colorLinks: false, iconSize: 'medium', iconizeLinks: true, renameLinks: false};`}
+      </Script>
+      <Script src="https://wow.zamimg.com/js/tooltips.js" />
+    </>
+  )
+} 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { DM_Sans } from "next/font/google";
 import "./globals.css";
 import { Analytics } from "@vercel/analytics/react";
+import WowheadScript from "./_components/WowheadScript";
 
 const dmSans = DM_Sans({ subsets: ["latin"] });
 
@@ -21,6 +22,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <WowheadScript />
       <body className={dmSans.className}>
         {children}
         <Analytics />


### PR DESCRIPTION
## Wowhead Tooltips
> Fixes #6 

Nice project! Found it through reddit. Had a bit of time available and always wanted to play with wowhead tooltips, din't know it was that easy tbh.

- Added the wowhead tooltips according to their documentation. 
- Created a component for the Script tags for the `<head />` section
- Removed the wowhead image since this will be replaced by the wowhead icon
- Tried to play around with the styles to make it look good, but this needs a bit more work

<details>
<summary>Screenshots</summary>
<img width="505" alt="Screenshot 2024-05-22 at 14 58 27" src="https://github.com/continentaldivide/remix-checklist/assets/408959/17727c58-5f60-4c41-a4cf-9f7ee7192c8f">
<img width="724" alt="Screenshot 2024-05-22 at 14 58 39" src="https://github.com/continentaldivide/remix-checklist/assets/408959/8db0e578-3bff-4a87-aa6b-9c6eb785e596">
<img width="582" alt="Screenshot 2024-05-22 at 14 58 52" src="https://github.com/continentaldivide/remix-checklist/assets/408959/4215a76d-a6be-4fc0-ab97-d12651ee9477">
</details>

### Todo 
- [ ] Fix styling