### PR TITLE
Persist options

### DIFF
--- a/app/_components/App.tsx
+++ b/app/_components/App.tsx
@@ -2,59 +2,26 @@ import bronze from "../_data/bronze";
 import Vendor from "../_components/Vendor";
 import { useEffect } from "react";
 import useCalculateBronze from "../_hooks/useCalculateBronze";
+import useGetLocalState from "../_hooks/useGetLocalState";
 import { useAppStateContext } from "../_context/AppStateContext";
 import NewsModal from "./NewsModal";
 
 export default function App() {
   const { appState, appStateDispatch } = useAppStateContext();
-  const defaultMap: Record<string, boolean> = {};
-  let bronzeTotal: number = 0;
 
-  const retrieveLocalMap = (
-    mapName: "checkedMap" | "vendorMap" | "ignoredVendorMap"
-  ) => {
-    const localMap = localStorage.getItem(mapName);
-    if (!localMap) {
-      localStorage.setItem(mapName, JSON.stringify(defaultMap));
-    } else {
-      const parsedLocalMap: Record<string, boolean> = JSON.parse(localMap);
-      //   ternary here is redundant but TS freaks out without it -- will revisit this later to try and understand the issue with my typing
-      if (mapName === "checkedMap") {
-        appStateDispatch({
-          type: `set ${mapName}`,
-          [mapName]: parsedLocalMap,
-        });
-      } else if (mapName === "vendorMap") {
-        appStateDispatch({
-          type: `set ${mapName}`,
-          [mapName]: parsedLocalMap,
-        });
-      } else if (mapName === "ignoredVendorMap") {
-        appStateDispatch({
-          type: `set ${mapName}`,
-          [mapName]: parsedLocalMap,
-        });
-      }
-    }
-  };
-
-  const handleScroll = () => {
-    appStateDispatch({ type: "set YPosition", position: window.scrollY });
-  };
+  useGetLocalState();
 
   useEffect(() => {
-    retrieveLocalMap("checkedMap");
-    retrieveLocalMap("vendorMap");
-    retrieveLocalMap("ignoredVendorMap");
-    const lastNewsVersion = localStorage.getItem("lastNewsVersion") || "";
-    appStateDispatch({ type: "set lastNewsVersion", version: lastNewsVersion });
+    const handleScroll = () => {
+      appStateDispatch({ type: "set YPosition", position: window.scrollY });
+    };
     window.addEventListener("scroll", handleScroll);
     return () => {
       window.removeEventListener("scroll", handleScroll);
     };
   }, []);
 
-  bronzeTotal = useCalculateBronze(
+  let bronzeTotal = useCalculateBronze(
     bronze,
     appState.checkedMap,
     appState.ignoredVendorMap,

--- a/app/_context/AppStateContext.tsx
+++ b/app/_context/AppStateContext.tsx
@@ -34,6 +34,11 @@ const appStateReducer: (
         ...state,
         lastNewsVersion: action.version,
       };
+    case "set ignoredItems":
+      return {
+        ...state,
+        ignoredItems: action.ignoredItems,
+      };
     case "set YPosition":
       return {
         ...state,

--- a/app/_context/AppStateContext.tsx
+++ b/app/_context/AppStateContext.tsx
@@ -29,6 +29,7 @@ const appStateReducer: (
         ignoredVendorMap: { ...action.ignoredVendorMap },
       };
     case "set lastNewsVersion":
+      // this piece of information needs to be persistent, so it's a little unintuitive that saving it to localStorage doesn't occur in this action and instead occurs in case "toggle news".  On revisiting this code, my intuition is that these cases should be able to be combined.  Can't do that right now but will try to come back soon.
       return {
         ...state,
         lastNewsVersion: action.version,
@@ -79,6 +80,13 @@ const appStateReducer: (
         menuOpen: !state.menuOpen,
       };
     case "toggle ignore":
+      localStorage.setItem(
+        "ignoredItems",
+        JSON.stringify({
+          ...state.ignoredItems,
+          [action.category]: !state.ignoredItems[action.category],
+        })
+      );
       return {
         ...state,
         ignoredItems: {

--- a/app/_data/updates.ts
+++ b/app/_data/updates.ts
@@ -3,7 +3,7 @@ import { UpdateType } from "../_interfaces/Update.interface";
 const updates: UpdateType[] = [
   {
     version: "1.0.1",
-    releaseDate: "June 11, 2024",
+    releaseDate: "June 28, 2024",
     changes: [
       "Added a menu with some new options for filtering out items.",
       "Added Theramore Tabard and fixed Mini Mana Bomb cost.",

--- a/app/_hooks/useGetLocalState.tsx
+++ b/app/_hooks/useGetLocalState.tsx
@@ -1,0 +1,31 @@
+import { useAppStateContext } from "../_context/AppStateContext";
+import { useEffect } from "react";
+
+export default function useGetLocalState() {
+  const { appStateDispatch } = useAppStateContext();
+  const defaultMap: Record<string, boolean> = {};
+
+  const retrieveLocalMap = (
+    mapName: "checkedMap" | "vendorMap" | "ignoredVendorMap"
+  ) => {
+    const localMap = localStorage.getItem(mapName);
+    if (!localMap) {
+      localStorage.setItem(mapName, JSON.stringify(defaultMap));
+    } else {
+      const parsedLocalMap: Record<string, boolean> = JSON.parse(localMap);
+      // dispatch action below makes TS mad because (if I've arrived at the correct understanding) it can't/won't check whether each member of the union string type of mapName results in correct typing.  Instead it infers the type of the computed property mapName as string which is insufficiently narrow to avoid errors.  Ref https://github.com/microsoft/TypeScript/issues/51734.
+      // @ts-ignore
+      appStateDispatch({
+        type: `set ${mapName}`,
+        [mapName]: parsedLocalMap,
+      });
+    }
+  };
+  useEffect(() => {
+    retrieveLocalMap("checkedMap");
+    retrieveLocalMap("vendorMap");
+    retrieveLocalMap("ignoredVendorMap");
+    const lastNewsVersion = localStorage.getItem("lastNewsVersion") || "";
+    appStateDispatch({ type: "set lastNewsVersion", version: lastNewsVersion });
+  }, []);
+}

--- a/app/_hooks/useGetLocalState.tsx
+++ b/app/_hooks/useGetLocalState.tsx
@@ -1,9 +1,17 @@
 import { useAppStateContext } from "../_context/AppStateContext";
 import { useEffect } from "react";
+import { IgnoredItemsType } from "../_interfaces/AppState.interface";
 
 export default function useGetLocalState() {
   const { appStateDispatch } = useAppStateContext();
   const defaultMap: Record<string, boolean> = {};
+  const defaultIgnoredItems: IgnoredItemsType = {
+    mounts: false,
+    toys: false,
+    armor: false,
+    nonEvent: false,
+    obtained: false,
+  };
 
   const retrieveLocalMap = (
     mapName: "checkedMap" | "vendorMap" | "ignoredVendorMap"
@@ -21,11 +29,24 @@ export default function useGetLocalState() {
       });
     }
   };
+
   useEffect(() => {
     retrieveLocalMap("checkedMap");
     retrieveLocalMap("vendorMap");
     retrieveLocalMap("ignoredVendorMap");
+
     const lastNewsVersion = localStorage.getItem("lastNewsVersion") || "";
     appStateDispatch({ type: "set lastNewsVersion", version: lastNewsVersion });
+
+    const localIgnored = localStorage.getItem("ignoredItems");
+    if (!localIgnored) {
+      localStorage.setItem("ignoredItems", JSON.stringify(defaultIgnoredItems));
+    } else {
+      const parsedLocalIgnored: IgnoredItemsType = JSON.parse(localIgnored);
+      appStateDispatch({
+        type: "set ignoredItems",
+        ignoredItems: parsedLocalIgnored,
+      });
+    }
   }, []);
 }

--- a/app/_interfaces/AppActions.interface.ts
+++ b/app/_interfaces/AppActions.interface.ts
@@ -1,3 +1,5 @@
+import { IgnoredItemsType } from "./AppState.interface";
+
 interface setCheckedMap {
   type: "set checkedMap";
   checkedMap: Record<string, boolean>;
@@ -16,6 +18,11 @@ interface setIgnoredVendorMap {
 interface setLastNewsVersion {
   type: "set lastNewsVersion";
   version: string;
+}
+
+interface setIgnoredItems {
+  type: "set ignoredItems";
+  ignoredItems: IgnoredItemsType;
 }
 
 interface setYPosition {
@@ -58,6 +65,7 @@ export type AppActionsType =
   | setVendorMap
   | setIgnoredVendorMap
   | setLastNewsVersion
+  | setIgnoredItems
   | setYPosition
   | toggleShowVendor
   | toggleIgnoreVendor


### PR DESCRIPTION
This PR's functionality is to preserve a user's menu option selections between sessions.  Under the hood, it refactors some business logic out of a component and into a hook.